### PR TITLE
bugfix: sizeof('c')=4, not 1, fix overallocations.

### DIFF
--- a/src/ngx_http_memc_request.c
+++ b/src/ngx_http_memc_request.c
@@ -384,7 +384,7 @@ ngx_http_memc_create_flush_all_cmd_request(ngx_http_request_t *r)
     if (!exptime_vv->not_found && exptime_vv->len) {
         dd("found exptime: %s", exptime_vv->data);
 
-        len += sizeof(' ') + exptime_vv->len;
+        len += sizeof(" ") - 1 + exptime_vv->len;
     }
 
     len += sizeof(CRLF) - 1;
@@ -451,12 +451,12 @@ ngx_http_memc_create_delete_cmd_request(ngx_http_request_t *r)
         return NGX_HTTP_INTERNAL_SERVER_ERROR;
     }
 
-    len = ctx->cmd_str.len + sizeof(' ') + key_vv->len + escape;
+    len = ctx->cmd_str.len + sizeof(" ") - 1 + key_vv->len + escape;
 
     if (!exptime_vv->not_found && exptime_vv->len) {
         dd("found exptime: %s", exptime_vv->data);
 
-        len += sizeof(' ') + exptime_vv->len;
+        len += sizeof(" ") - 1 + exptime_vv->len;
     }
 
     len += sizeof(CRLF) - 1;
@@ -531,8 +531,8 @@ ngx_http_memc_create_incr_decr_cmd_request(ngx_http_request_t *r)
 
     /* XXX validate if $memc_value_vv is a valid uint64 string */
 
-    len = ctx->cmd_str.len + sizeof(' ') + key_vv->len + escape
-        + sizeof(' ') + value_vv->len + sizeof(CRLF) - 1;
+    len = ctx->cmd_str.len + sizeof(" ") - 1 + key_vv->len + escape
+        + sizeof(" ") - 1 + value_vv->len + sizeof(CRLF) - 1;
 
     b = ngx_create_temp_buf(r->pool, len);
     if (b == NULL) {


### PR DESCRIPTION
As found by DCS `[^._]sizeof[ (]'.{1,2}' filetype:c`

Ref: https://paste.sr.ht/~nabijaczleweli/6ee9ccf301a2651afb693bff46e3671d3f7cdd89
Ref: https://101010.pl/@nabijaczleweli/111587138076843793